### PR TITLE
Basic logic for symlinks/hardlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Voila!
 * `readFile <name>`    - Reads the contents of the specified file in the current directory (truncated after 2000 chars)
 * `mvfile <name> <target>`  - Moves the specified file to the given target directory.
 * `find <name> <useRecursion> `  - Finds files or directories with the specified name. Set `useRecursion` to true to search subdirectories.
+* `link <target> <name> `  - Creates a hard link to the specified target with the given name. Only supports hard links for files
+* `symlink <target> <name>` - Creates a symbolic link (symlink) to the specified target (file or directory) with the given name.  
 
 ### Testing
 ```

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ var ValidInputMap = map[string][]int{
 	"readfile":  {1},
 	"mvfile":    {2},
 	"find":      {2},
+	"symlink":   {2},
+	"link":      {2},
 }
 
 const HelpText string = `Commands:
@@ -35,6 +37,9 @@ writeFile <name>    	Writes contents to the specified file in the current direct
 readFile <name>     	Reads the contents of the specified file in the current directory.
 mvfile <name> <target>  	Moves the specified file to the given target directory.
 find <name> <useRecursion>     	Finds files or directories with the specified name. Set useRecursion to true to search subdirectories.
+link <target> <name>   Creates a hard link to the specified target with the given name. Only supports hard links for files
+symlink <target> <name>  Creates a symbolic link (symlink) to the specified target (file or directory) with the given name.  
+-------------------------
 help                	Displays this help menu.
 exit                	Exits the program.`
 
@@ -134,6 +139,10 @@ func parseUserInputs(fs *src.Filesystem, inputs []string) error {
 		}
 		res := fs.FindFileOrDir(params[0], bVal)
 		fmt.Println(strings.Join(res, ","))
+	case "link":
+		printResults(fs.CreateHardlink(params[0], params[1]))
+	case "symlink":
+		printResults(fs.CreateSymlink(params[0], params[1]))
 	default:
 		return fmt.Errorf("Invalid method call %s - please run 'help' for more details", method)
 	}

--- a/src/util/link.go
+++ b/src/util/link.go
@@ -1,0 +1,57 @@
+package util
+
+type Link interface {
+	GetTarget() *File
+	RemoveTarget()
+	IsSymLink() bool
+}
+
+// Symlinks point to the path to the target file, not the file itself
+type SymLink struct {
+	name   string
+	target *File
+}
+
+// Hard links point to an underlying file (not a directory)
+type HardLink struct {
+	name   string
+	target *File
+}
+
+func NewSymLink(name string, target *File) *SymLink {
+	return &SymLink{
+		name:   name,
+		target: target,
+	}
+}
+
+func NewHardLink(name string, target *File) *HardLink {
+	return &HardLink{
+		name:   name,
+		target: target,
+	}
+}
+
+func (hl *HardLink) GetTarget() *File {
+	return hl.target
+}
+
+func (sl *SymLink) GetTarget() *File {
+	return sl.target
+}
+
+func (hl *HardLink) RemoveTarget() {
+	hl.target = nil
+}
+
+func (sl *SymLink) RemoveTarget() {
+	sl.target = nil
+}
+
+func (hl *HardLink) IsSymLink() bool {
+	return false
+}
+
+func (sl *SymLink) IsSymLink() bool {
+	return true
+}


### PR DESCRIPTION
- Create a new `Link` interface that is implemented by `SymLink`s and `HardLink`s
- Hard links are supported for files only, not directories
- Links to a file/directory are stored within the `File` object itself
- A fs-level map stores all links by name for easy lookups 
- Supports creating new symlinks/hardlinks via new methods - also added in README
- When we remove a symlink/hardlink, just remove the link
- When we remove a file/dir referenced via symlink, the symlink points at nothing. When we remove a file referenced via hard link, the hard link's target should not change and we can still read file contents 
- TODO: better handle when a directory/file is moved 